### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM golang:latest
+WORKDIR /go/src/github.com/google/huproxy
+COPY . .
+RUN mkdir /app
+RUN go get -d -v .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o /app .
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o /app ./huproxyclient
+
+FROM alpine:latest
+WORKDIR /
+COPY --from=0 /app/ .
+CMD ["/huproxy"]


### PR DESCRIPTION
Here is a straightforward Dockerfile which uses multi-stage builds to build `huproxy` and `huproxyclient` and wraps them up in a small Alpine container. I'm currently publishing this at https://hub.docker.com/r/bootc/huproxy and using it to run a HUProxy instance in my lab Kubernetes cluster, where it seems to work well.